### PR TITLE
Handle previous and next pages, show upvotes for threads and comments…

### DIFF
--- a/reddit.el
+++ b/reddit.el
@@ -45,21 +45,29 @@
 (require 'tree-mode)
 (require 'markdown-mode)
 
+
 ;;;; Variables
+
 (defvar reddit-root "http://www.reddit.com")
 (defvar reddit-api-root "http://www.reddit.com/api")
 (defvar reddit-site '(main))
+
 (defvar reddit-entry-format "%N. %[%T%] (%D, %C comments, %U upvotes)\n")
+
 (defvar reddit-user nil)
 (defvar reddit-password nil)
+
 (defvar reddit-threads-limit "30")
 (defvar reddit-entry-id nil)
 (defvar reddit-parent-id nil)
+
 (defvar reddit-kind-listing "Listing")
 (defvar reddit-kind-comment "t1")
 (defvar reddit-kind-entry "t3")
 
+
 ;;;; Utilities
+
 (defmacro reddit-alet (vars alist &rest forms)
   (let ((alist-var (make-symbol "alist")))
     `(let* ((,alist-var ,alist)
@@ -93,7 +101,9 @@
           do (insert delim key "=" value))
     (buffer-string)))
 
+
 ;;;; Reddit-specific utilities
+
 (defun reddit-parse ()
   (goto-char (point-min))
   (re-search-forward "^$")
@@ -175,7 +185,9 @@
         (error "Can't find modhash; not logged in?")
       modhash)))
 
+
 ;;;; Reddit mode
+
 (defun reddit ()
   "Switch to Reddit buffer, creating it if necessary."
   (interactive)
@@ -305,6 +317,7 @@ MSubreddit: ")
                     (list (current-buffer))))))
 
 ;;;; Reddit Comments mode
+
 (defun reddit-comments ()
   (interactive)
   (let ((widget (widget-at)))
@@ -434,7 +447,9 @@ MSubreddit: ")
                  ,(widget-get comment :reddit-author))
        reddit-entry-id))))
 
+
 ;;;; Reddit Post mode
+
 (defun reddit-post-new-buffer (parent-id entry-id)
   (with-current-buffer (get-buffer-create (format "*Reddit Post %s*" parent-id))
     (reddit-post-mode)
@@ -470,7 +485,9 @@ MSubreddit: ")
       (reddit-kill)
       (message "Posted followup to comment by %s" author))))
 
+
 ;;;; Finally...
+
 (provide 'reddit)
 
 ;;; reddit.el ends here

--- a/reddit.el
+++ b/reddit.el
@@ -134,17 +134,17 @@
         (message "Login successful")))))
 
 (defun reddit-site-json (&optional after-param before-param)
+  (if (and after-param before-param)
+      (error "Only one param should be provided"))
   (let ((reddit-base (concat reddit-root "/.json?limit=" reddit-threads-limit))
         (reddit-subreddit-base (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit)))
     (ecase (first reddit-site)
       (main
-       (cond ((and after-param before-param) (error "Only one param should be provided"))
-             (after-param (concat reddit-base "&after=" after-param))
+       (cond (after-param (concat reddit-base "&after=" after-param))
              (before-param (concat reddit-base "&before=" before-param))
              (t reddit-base)))
       (subreddit
-       (cond ((and after-param before-param) (error "Only one param should be provided"))
-             (after-param (concat reddit-subreddit-base "&after=" after-param))
+       (cond (after-param (concat reddit-subreddit-base "&after=" after-param))
              (before-param (concat reddit-subreddit-base "&before=" before-param))
              (t reddit-subreddit-base)))
       (search (destructuring-bind (query &optional subreddit)

--- a/reddit.el
+++ b/reddit.el
@@ -289,7 +289,6 @@ MSubreddit: ")
                     'reddit-refresh-cb
                     (list (current-buffer))))))
 
-;; Get previous page threads
 (defun reddit-prev ()
   "Get previous page of threads"
   (interactive)

--- a/reddit.el
+++ b/reddit.el
@@ -411,12 +411,12 @@ MSubreddit: ")
 
 (defun reddit-comments-current-comment ()
   (labels ((lookup (widget)
-                   (cond ((null widget)
-                          nil)
-                         ((not (eq 'reddit-comment-widget (widget-type widget)))
-                          (lookup (widget-get widget :parent)))
-                         (t
-                          widget))))
+             (cond ((null widget)
+                    nil)
+                   ((not (eq 'reddit-comment-widget (widget-type widget)))
+                    (lookup (widget-get widget :parent)))
+                   (t
+                    widget))))
     (lookup (tree-mode-icon-current-line))))
 
 (defun reddit-comments-post ()

--- a/reddit.el
+++ b/reddit.el
@@ -135,24 +135,24 @@
 
 (defun reddit-site-json (&optional after-param before-param)
   (if (and after-param before-param)
-      (error "Only one param should be provided"))
-  (let ((reddit-base (concat reddit-root "/.json?limit=" reddit-threads-limit))
-        (reddit-subreddit-base (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit)))
-    (ecase (first reddit-site)
-      (main
-       (cond (after-param (concat reddit-base "&after=" after-param))
-             (before-param (concat reddit-base "&before=" before-param))
-             (t reddit-base)))
-      (subreddit
-       (cond (after-param (concat reddit-subreddit-base "&after=" after-param))
-             (before-param (concat reddit-subreddit-base "&before=" before-param))
-             (t reddit-subreddit-base)))
-      (search (destructuring-bind (query &optional subreddit)
-                  (rest reddit-site)
-                (setq query (url-hexify-string query))
-                (if subreddit
-                    (concat reddit-root "/r/" subreddit "/search.json?q=" query)
-                  (concat reddit-root "/search.json?q=" query)))))))
+      (error "Only one param should be provided")
+    (let ((reddit-base (concat reddit-root "/.json?limit=" reddit-threads-limit))
+          (reddit-subreddit-base (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit)))
+      (ecase (first reddit-site)
+        (main
+         (cond (after-param (concat reddit-base "&after=" after-param))
+               (before-param (concat reddit-base "&before=" before-param))
+               (t reddit-base)))
+        (subreddit
+         (cond (after-param (concat reddit-subreddit-base "&after=" after-param))
+               (before-param (concat reddit-subreddit-base "&before=" before-param))
+               (t reddit-subreddit-base)))
+        (search (destructuring-bind (query &optional subreddit)
+                    (rest reddit-site)
+                  (setq query (url-hexify-string query))
+                  (if subreddit
+                      (concat reddit-root "/r/" subreddit "/search.json?q=" query)
+                    (concat reddit-root "/search.json?q=" query))))))))
 
 (defun reddit-comments-site-root (entry-id)
   (concat reddit-root "/info/" entry-id "/comments"))

--- a/reddit.el
+++ b/reddit.el
@@ -1,10 +1,16 @@
 ;;; reddit.el --- Support for the Reddit time sink
+
 ;; Copyright (C) 2008 DEATH
 ;; Copyright (C) 2015 massix
+
 ;; Authors: DEATH, massix
 ;; Keywords: games
 ;; Website: http://github.com/death http://github.com/massix
+
 ;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
 ;;;  _ __ ___  __| | __| (_) |_      _ __ ___   ___   __| | ___
 ;;; | '__/ _ \/ _` |/ _` | | __|____| '_ ` _ \ / _ \ / _` |/ _ \
 ;;; | | |  __/ (_| | (_| | | ||_____| | | | | | (_) | (_| |  __/

--- a/reddit.el
+++ b/reddit.el
@@ -1,40 +1,14 @@
 ;;; reddit.el --- Support for the Reddit time sink
-
 ;; Copyright (C) 2008 DEATH
-
-;; Author: DEATH
+;; Copyright (C) 2015 massix
+;; Authors: DEATH, massix
 ;; Keywords: games
-;; Website: http://github.com/death
-
+;; Website: http://github.com/death http://github.com/massix
 ;; This file is not part of GNU Emacs.
-
-;;; Commentary:
-
 ;;;  _ __ ___  __| | __| (_) |_      _ __ ___   ___   __| | ___
 ;;; | '__/ _ \/ _` |/ _` | | __|____| '_ ` _ \ / _ \ / _` |/ _ \
 ;;; | | |  __/ (_| | (_| | | ||_____| | | | | | (_) | (_| |  __/
 ;;; |_|  \___|\__,_|\__,_|_|\__|    |_| |_| |_|\___/ \__,_|\___|
-;;;
-;;; A lot of stuff is missing:
-;;;
-;;; - logout
-;;; - markdown
-;;; - comments: edit/delete
-;;; - submitting urls (incl. delete)
-;;; - voting urls/comments
-;;; - saving links
-;;; - other pages (e.g. what's new/browse/saved/recommended/stats/blog)
-;;; - user pages
-;;; - user preferences
-;;; - customization
-;;; - documentation
-;;; - menus
-;;; - error checking
-;;; - handle <more comments>
-;;; - much more...
-;;;
-
-;;; Code:
 
 (require 'cl)
 (require 'thingatpt)
@@ -44,28 +18,21 @@
 (require 'tree-mode)
 (require 'markdown-mode)
 
-
 ;;;; Variables
-
 (defvar reddit-root "http://www.reddit.com")
 (defvar reddit-api-root "http://www.reddit.com/api")
 (defvar reddit-site '(main))
-
-(defvar reddit-entry-format "%N. %[%T%] (%D, %C comments)\n")
-
+(defvar reddit-entry-format "%N. %[%T%] (%D, %C comments, %U upvotes)\n")
 (defvar reddit-user nil)
 (defvar reddit-password nil)
-
 (defvar reddit-entry-id nil)
 (defvar reddit-parent-id nil)
-
 (defvar reddit-kind-listing "Listing")
 (defvar reddit-kind-comment "t1")
 (defvar reddit-kind-entry "t3")
+(defvar reddit-default-limit "30")
 
-
 ;;;; Utilities
-
 (defmacro reddit-alet (vars alist &rest forms)
   (let ((alist-var (make-symbol "alist")))
     `(let* ((,alist-var ,alist)
@@ -99,9 +66,7 @@
           do (insert delim key "=" value))
     (buffer-string)))
 
-
 ;;;; Reddit-specific utilities
-
 (defun reddit-parse ()
   (goto-char (point-min))
   (re-search-forward "^$")
@@ -110,7 +75,7 @@
 (defun reddit-api (op data)
   (let* ((url-request-method "POST")
          (url-request-extra-headers
-          '(("Content-Type" . "application/x-www-form-urlencoded"))) 
+          '(("Content-Type" . "application/x-www-form-urlencoded")))
          (url-request-data
           (reddit-format-request-data
            (append data
@@ -147,10 +112,24 @@
                  (assoc-default 'message error nil "<no message>"))
         (message "Login successful")))))
 
-(defun reddit-site-json ()
+(defun reddit-site-json (&optional after-param before-param)
   (ecase (first reddit-site)
-    (main (concat reddit-root "/.json"))
-    (subreddit (concat reddit-root "/r/" (second reddit-site) "/.json"))
+    (main
+     (cond ((and after-param before-param) (error "Only one param should be provided"))
+           (after-param
+            (concat reddit-root "/.json?limit=" reddit-default-limit "&after=" after-param))
+           (before-param
+            (concat reddit-root "/.json?limit=" reddit-default-limit "&before=" before-param))
+           (t
+            (concat reddit-root "/.json?limit=" reddit-default-limit))))
+    (subreddit
+     (cond ((and after-param before-param) (error "Only one param should be provided"))
+           (after-param
+            (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-default-limit "&after=" after-param))
+           (before-param
+            (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-default-limit "&before=" before-param))
+           (t
+            (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-default-limit))))
     (search (destructuring-bind (query &optional subreddit)
                 (rest reddit-site)
               (setq query (url-hexify-string query))
@@ -173,9 +152,7 @@
         (error "Can't find modhash; not logged in?")
       modhash)))
 
-
 ;;;; Reddit mode
-
 (defun reddit ()
   "Switch to Reddit buffer, creating it if necessary."
   (interactive)
@@ -192,6 +169,8 @@
     (define-key map "c" 'reddit-comments)
     (define-key map "L" 'reddit-login)
     (define-key map "S" 'reddit-search)
+    (define-key map "n" 'reddit-next)
+    (define-key map "p" 'reddit-prev)
     map))
 
 (define-derived-mode reddit-mode nil "Reddit"
@@ -211,7 +190,7 @@
   (format "*Reddit %S*" site))
 
 (defun reddit-search (&optional query subreddit)
-  (interactive "MSearch: 
+  (interactive "MSearch:
 MSubreddit: ")
   (when (string= query "") (setq query nil))
   (when (string= subreddit "") (setq subreddit nil))
@@ -238,7 +217,7 @@ MSubreddit: ")
       (erase-buffer)
       (let ((kind (assoc-default 'kind data)))
         (assert (equal reddit-kind-listing kind))
-        (let ((children (assoc-default 'children (car data))))
+        (let ((children (assoc-default 'children (assoc-default 'data data))))
           (loop for n from 0
                 for child across children
                 do (widget-create (reddit-make-entry child n)))))
@@ -262,6 +241,7 @@ MSubreddit: ")
             :value url
             :help-echo url
             :tab-order n
+            :reddit-upvotes ups
             :reddit-title title
             :reddit-entry-id id
             :reddit-n n
@@ -273,18 +253,35 @@ MSubreddit: ")
 
 (defun reddit-entry-format (widget char)
   (case char
-    (?N (insert (format "%2d" (1+ (widget-get widget :reddit-n)))))
+    (?N (insert (format "%3d" (1+ (widget-get widget :reddit-n)))))
     (?D (insert (widget-get widget :reddit-domain)))
     (?T (insert (truncate-string-to-width (widget-get widget :reddit-title) 80 nil nil t)))
     (?S (insert (format "%d" (widget-get widget :reddit-score))))
     (?A (insert (widget-get widget :reddit-author)))
     (?C (insert (format "%d" (widget-get widget :reddit-num-comments))))
     (?R (insert (widget-get widget :reddit-subreddit)))
+    (?U (insert (format "%d" (widget-get widget :reddit-upvotes))))
     (t (widget-default-format-handler widget char))))
 
-
+;; Get next page of threads
+(defun reddit-next ()
+  (interactive)
+  (let ((widget (widget-at)))
+    (when widget
+      (url-retrieve (reddit-site-json (concat reddit-kind-entry "_" (widget-get widget :reddit-entry-id)) nil)
+                    'reddit-refresh-cb
+                    (list (current-buffer))))))
+
+;; Get previous page threads
+(defun reddit-prev ()
+  (interactive)
+  (let ((widget (widget-at)))
+    (when widget
+      (url-retrieve (reddit-site-json nil (concat reddit-kind-entry "_" (widget-get widget :reddit-entry-id)))
+                    'reddit-refresh-cb
+                    (list (current-buffer))))))
+
 ;;;; Reddit Comments mode
-                    
 (defun reddit-comments ()
   (interactive)
   (let ((widget (widget-at)))
@@ -310,6 +307,7 @@ MSubreddit: ")
 
 (defun reddit-comments-refresh ()
   (interactive)
+  (message "Retrieving comments for %s" (concat (reddit-comments-site-root reddit-entry-id) "/.json"))
   (url-retrieve (concat (reddit-comments-site-root reddit-entry-id) "/.json")
                 'reddit-comments-refresh-cb
                 (list (current-buffer))))
@@ -323,17 +321,21 @@ MSubreddit: ")
   (with-current-buffer buffer
     (let ((inhibit-read-only t))
       (erase-buffer)
-      ;; The first element of data contains the reddit entry.  The
+      ;; The first element of data contains the reddit entry. The
       ;; second element of data contains all the comments.
       (if (or (not (arrayp data))
               (< (length data) 2))
           (error "Weird data: %s" data)
-        (let* ((data (assoc-default 'data (aref data 1)))
+        (let* ((entry (assoc-default 'data (aref data 0)))
+               (data (assoc-default 'data (aref data 1)))
                (children (assoc-default 'children data))
                (trees (reddit-comments-trees children)))
           (dolist (tree trees)
             (tree-mode-expand-level-1 (tree-mode-insert tree) -1))
           (goto-char (point-min))
+          (let ((text (assoc-default 'selftext (assoc-default 'data (aref (assoc-default 'children entry) 0)))))
+            (insert text "\n\n")
+            (fill-region (point-min) (point)))
           (message "Got comments"))))))
 
 (define-widget 'reddit-comment-widget 'tree-widget
@@ -355,7 +357,9 @@ MSubreddit: ")
                `((reddit-comment-widget
                   :reddit-comment-id ,id
                   :reddit-author ,author
-                  :node (push-button :tag ,author :format "%t\n")
+                  :reddit-upvotes ,ups
+                  :node (push-button :tag ,author
+                                     :format ,(format "%%[%%t%%] (%d point(s))\n" ups))
                   ,@(reddit-comments-body-widgets body)
                   ,@(when replies
                       (reddit-comments-trees replies))))))
@@ -386,12 +390,12 @@ MSubreddit: ")
 
 (defun reddit-comments-current-comment ()
   (labels ((lookup (widget)
-             (cond ((null widget)
-                    nil)
-                   ((not (eq 'reddit-comment-widget (widget-type widget)))
-                    (lookup (widget-get widget :parent)))
-                   (t
-                    widget))))
+                   (cond ((null widget)
+                          nil)
+                         ((not (eq 'reddit-comment-widget (widget-type widget)))
+                          (lookup (widget-get widget :parent)))
+                         (t
+                          widget))))
     (lookup (tree-mode-icon-current-line))))
 
 (defun reddit-comments-post ()
@@ -407,9 +411,8 @@ MSubreddit: ")
        `(comment ,(widget-get comment :reddit-comment-id)
                  ,(widget-get comment :reddit-author))
        reddit-entry-id))))
-
-;;;; Reddit Post mode
 
+;;;; Reddit Post mode
 (defun reddit-post-new-buffer (parent-id entry-id)
   (with-current-buffer (get-buffer-create (format "*Reddit Post %s*" parent-id))
     (reddit-post-mode)
@@ -445,9 +448,7 @@ MSubreddit: ")
       (reddit-kill)
       (message "Posted followup to comment by %s" author))))
 
-
 ;;;; Finally...
-
 (provide 'reddit)
 
 ;;; reddit.el ends here

--- a/reddit.el
+++ b/reddit.el
@@ -134,29 +134,25 @@
         (message "Login successful")))))
 
 (defun reddit-site-json (&optional after-param before-param)
-  (ecase (first reddit-site)
-    (main
-     (cond ((and after-param before-param) (error "Only one param should be provided"))
-           (after-param
-            (concat reddit-root "/.json?limit=" reddit-threads-limit "&after=" after-param))
-           (before-param
-            (concat reddit-root "/.json?limit=" reddit-threads-limit "&before=" before-param))
-           (t
-            (concat reddit-root "/.json?limit=" reddit-threads-limit))))
-    (subreddit
-     (cond ((and after-param before-param) (error "Only one param should be provided"))
-           (after-param
-            (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit "&after=" after-param))
-           (before-param
-            (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit "&before=" before-param))
-           (t
-            (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit))))
-    (search (destructuring-bind (query &optional subreddit)
-                (rest reddit-site)
-              (setq query (url-hexify-string query))
-              (if subreddit
-                  (concat reddit-root "/r/" subreddit "/search.json?q=" query)
-                (concat reddit-root "/search.json?q=" query))))))
+  (let ((reddit-base (concat reddit-root "/.json?limit=" reddit-threads-limit))
+        (reddit-subreddit-base (concat reddit-root "/r/" (second reddit-site) "/.json?limit=" reddit-threads-limit)))
+    (ecase (first reddit-site)
+      (main
+       (cond ((and after-param before-param) (error "Only one param should be provided"))
+             (after-param (concat reddit-base "&after=" after-param))
+             (before-param (concat reddit-base "&before=" before-param))
+             (t reddit-base)))
+      (subreddit
+       (cond ((and after-param before-param) (error "Only one param should be provided"))
+             (after-param (concat reddit-subreddit-base "&after=" after-param))
+             (before-param (concat reddit-subreddit-base "&before=" before-param))
+             (t reddit-subreddit-base)))
+      (search (destructuring-bind (query &optional subreddit)
+                  (rest reddit-site)
+                (setq query (url-hexify-string query))
+                (if subreddit
+                    (concat reddit-root "/r/" subreddit "/search.json?q=" query)
+                  (concat reddit-root "/search.json?q=" query)))))))
 
 (defun reddit-comments-site-root (entry-id)
   (concat reddit-root "/info/" entry-id "/comments"))


### PR DESCRIPTION
…, some other minor fixes


Hi!
I don't know if this repo is still alive: I stumbled upon this script while looking for a way to browse reddit at work without getting caught ( :D ) and noticed that it didn't work properly with emacs 25, so I decided to fix some things here and there.

* Fixed a bug that prevented the parsing of the json structure, I don't know if Reddit's APIs have changed since the creation of this script, but we now have a lot of arrays.
* Added a new "next/prev page" function, bound them to "n" and "p" keys in the default keymap
* Show the parent thread when reading comments (useful in case of self threads as I'm used to, since I mainly browse /r/boardgames)
* Added a new "reddit-default-limit" variable which handles how many threads per page are shown, default value is "30", can be increased/decreased via a simple setq
* Added upvotes in comments and threads

Let me know if you're interested in this PR, otherwise feel free to ignore it.

Thanks a lot for this script, it really helped decreasing my productivity at work ! :+1: 