### PR TITLE
Restrict search to specified subreddit

### DIFF
--- a/reddit.el
+++ b/reddit.el
@@ -168,7 +168,7 @@
                     (rest reddit-site)
                   (setq query (url-hexify-string query))
                   (if subreddit
-                      (concat reddit-root "/r/" subreddit "/search.json?q=" query)
+                      (concat reddit-root "/r/" subreddit "/search.json?&restrict_sr=true&q=" query)
                     (concat reddit-root "/search.json?q=" query))))))))
 
 (defun reddit-comments-site-root (entry-id)


### PR DESCRIPTION
Thanks for the awesome package, been using it for while. With all due respect I noticed one issue with the search.

When searching it returns all the results from all subreddits. Adding 'restrict_sr' param to search query when subbreddit is specified would restrict search to specified subreddit.

These are results before the change - searching for word "string" in subreddit "emacs". As you can see the results are from all of the reddit.
![before](https://user-images.githubusercontent.com/6223406/30959897-2d455dd0-a44a-11e7-886c-f8d4faadb898.png)

After the change the results are only from the emacs subreddit.
![after](https://user-images.githubusercontent.com/6223406/30959900-2e4a87be-a44a-11e7-8fb7-6af15b205d7c.png)

Thanks again for the great work!

